### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -341,7 +341,7 @@ def ajax_add_item(request):
 
     except (json.JSONDecodeError, KeyError, TypeError) as e:
         logger.error("Error adding item: %s", e)
-        return JsonResponse({"error": str(e)}, status=500)
+        return JsonResponse({"error": "Failed to add item due to internal error."}, status=500)
 
 
 # filter so nsfw stuff won't be added from ebay if a user searches for it, and block searches too


### PR DESCRIPTION
Potential fix for [https://github.com/best-dressed/cs4300-BestDressed/security/code-scanning/5](https://github.com/best-dressed/cs4300-BestDressed/security/code-scanning/5)

The best practice is to avoid returning exception messages directly to clients. Instead, catch the exception, log the relevant details (already done via `logger.error`), and return a generic error message in the HTTP response. This ensures clients do not learn details about the backend, while developers can still access full error information in the logs.

**To implement:**
- Edit `api/views.py`, specifically the `except` block of the `ajax_add_item` view (lines 342–344).
- Replace `JsonResponse({"error": str(e)}, status=500)` with a generic error message, such as `JsonResponse({"error": "Failed to add item due to internal error."}, status=500)`.

No new methods or imports are required since logging is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
