### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_bestdressed.yml
+++ b/.github/workflows/main_bestdressed.yml
@@ -58,6 +58,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -1,4 +1,6 @@
 name: Python Tests + Linting
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/best-dressed/cs4300-BestDressed/security/code-scanning/2](https://github.com/best-dressed/cs4300-BestDressed/security/code-scanning/2)

To fix the flagged issue, you should add an explicit `permissions` block to the `test` job in `.github/workflows/main_bestdressed.yml`. Since your `test` job only needs to fetch repository contents and does not write to the repo or perform privileged operations, you should set its permissions to only allow read access to repository contents. This is done by adding:

```yaml
permissions:
  contents: read
```

as a top-level key under the `test` job definition (after `runs-on` and before `steps`). This change will not affect any of the job’s existing functionality and will ensure the GITHUB_TOKEN for the job has only the minimal privileges required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
